### PR TITLE
Added: Optional Name Fields & New Library Folder Format

### DIFF
--- a/SAMAPI/LibraryFolders.cs
+++ b/SAMAPI/LibraryFolders.cs
@@ -10,7 +10,7 @@ namespace Indieteur.SAMAPI
         const string LIBRARY_FOLDERS_NAME = "libraryfolders.vdf"; //The default file name of the file which lists all the library folders of steam.
         const string LIBFILE_NODE_NAME = "LibraryFolders"; //The node name inside the Library Folders file which contains the list of our steam libraries
         const string APPMANIFEST_SEARCH_STRING = "appmanifest_*.acf"; //The search pattern to be used for searching steam apps manifest.
-
+        const string LIBRARYFOLDER_NODE_PATH_NAME = "path"; //The search pattern to be used for searching steam apps manifest.
 
         /// <summary>
         /// Lists all the library folders of the steam installation.
@@ -42,6 +42,19 @@ namespace Indieteur.SAMAPI
                     libraryFolders.Add(vKey.Value); 
                 }
             }
+
+            foreach (VDFNode node in vNode.Nodes) //List all the keys inside the vNode node.
+            {
+                if (node.Name.IsInteger()) //As per what I've seen from the Library Folders file, it seems that the key name for the location of the folders itself is a number so check if the key name is a number.
+                {
+                    var pathKey = node.Keys.FindKey(LIBRARYFOLDER_NODE_PATH_NAME);
+                    if (pathKey == null)
+                        continue;
+
+                    libraryFolders.Add(pathKey.Value);
+                }
+            }
+
             return libraryFolders;
         }
 

--- a/SAMAPI/LibraryFolders.cs
+++ b/SAMAPI/LibraryFolders.cs
@@ -32,26 +32,32 @@ namespace Indieteur.SAMAPI
 
             VDFNode vNode = vdfReader.Nodes.FindNode(LIBFILE_NODE_NAME); //Find the node that contains the list of steam libraries.
 
-            if (vNode == null || vNode.Keys == null || vNode.Keys.Count == 0) //If it isn't found or the Nodes key is null or empty, there's nothing else to be done. Return the list of libraryfolders that we already have. (which is just MainSteamInstallPath)
+            if (vNode == null) //If it isn't found or the Nodes key is null or empty, there's nothing else to be done. Return the list of libraryfolders that we already have. (which is just MainSteamInstallPath)
                 return libraryFolders;
 
-            foreach (VDFKey vKey in vNode.Keys) //List all the keys inside the vNode node.
+            if (vNode.Keys != null)
             {
-                if (vKey.Name.IsInteger()) //As per what I've seen from the Library Folders file, it seems that the key name for the location of the folders itself is a number so check if the key name is a number.
+                foreach (VDFKey vKey in vNode.Keys) //List all the keys inside the vNode node.
                 {
-                    libraryFolders.Add(vKey.Value); 
+                    if (vKey.Name.IsInteger()) //As per what I've seen from the Library Folders file, it seems that the key name for the location of the folders itself is a number so check if the key name is a number.
+                    {
+                        libraryFolders.Add(vKey.Value);
+                    }
                 }
             }
 
-            foreach (VDFNode node in vNode.Nodes) //List all the keys inside the vNode node.
+            if (vNode.Nodes != null)
             {
-                if (node.Name.IsInteger()) //As per what I've seen from the Library Folders file, it seems that the key name for the location of the folders itself is a number so check if the key name is a number.
+                foreach (VDFNode node in vNode.Nodes) //List all the keys inside the vNode node.
                 {
-                    var pathKey = node.Keys.FindKey(LIBRARYFOLDER_NODE_PATH_NAME);
-                    if (pathKey == null)
-                        continue;
+                    if (node.Name.IsInteger()) //As per what I've seen from the Library Folders file, it seems that the key name for the location of the folders itself is a number so check if the key name is a number.
+                    {
+                        var pathKey = node.Keys.FindKey(LIBRARYFOLDER_NODE_PATH_NAME);
+                        if (pathKey == null)
+                            continue;
 
-                    libraryFolders.Add(pathKey.Value);
+                        libraryFolders.Add(pathKey.Value);
+                    }
                 }
             }
 

--- a/SAMAPI/SteamApp.cs
+++ b/SAMAPI/SteamApp.cs
@@ -22,6 +22,7 @@ namespace Indieteur.SAMAPI
 
         /// <summary>
         /// The name of the Steam application.
+        /// This name may be empty for old/legacy packages, such as old installs of Source 2007 Dedicated Server.
         /// </summary>
         public string Name { get { return _Name; } }
         /// <summary>
@@ -124,12 +125,10 @@ namespace Indieteur.SAMAPI
             if (vNode.Keys == null || vNode.Keys.Count == 0)
                 throw new NullReferenceException("Node " + MANIFEST_NODE + " list of keys is either null or empty!");
 
-            VDFKey vKey = vNode.Keys.FindKey(MANIFEST_KEY_NAME); //Locate our first key which will be the name of the app.
+            VDFKey vKey;
 
-            if (vKey != null) 
-                _Name = vKey.Value;
-            else
-                throw new NullReferenceException("Key pertaining to the name of the app is not found under " + MANIFEST_NODE + " node.");
+            // Not all applications have a name; please note applications such as "Source 2007 Dedicated Server" (ID: 310)
+            _Name = vNode.Keys.FindKey(MANIFEST_KEY_NAME)?.Value;
 
             vKey = vNode.Keys.FindKey(MANIFEST_KEY_APPID); 
 
@@ -156,7 +155,6 @@ namespace Indieteur.SAMAPI
             }
             else
                 throw new NullReferenceException("Key pertaining to the directory name containing the app under " + MANIFEST_NODE + " node is not found!");
-
         }
 
         /// <summary>


### PR DESCRIPTION
This PR adds code related to format changes of the Steam files over time.

**Legacy Packages**

When using the library, I found some users reported that certain very old packages, such as ` Source 2007 Dedicated Server` (ID: 310), might not have a name in their `acf` file. 

I'm not sure when the change is made, but it seemed to happen with people who mostly installed Steam a long time ago. As such, I added a fail-safe to ensure no exception is thrown and the whole operation doesn't fail when a single name is missing.

**New Library Folder Format**

Recent Steam installations will use a new format for storing library folders, which holds more metadata about each individual library folder.

Old:
![](https://cdn.discordapp.com/attachments/563005172985626645/857124081946460170/unknown.png)

New:
![](https://cdn.discordapp.com/attachments/563005172985626645/857124115127074836/unknown.png)

As the current version looks for keys rather than nodes, I added extra code to also check the nodes for any library folders.